### PR TITLE
refactor: replace `cli-color` with `picocolors`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
 
-const clc = require('cli-color');
+const colors = require('picocolors');
 
 let currentModulesNames = [];
 let currentLevel = 0;
@@ -17,11 +17,11 @@ let currentDecorate = true;
 const levelsText = ['Verb', 'Info', 'Warn', 'Err', 'Dbg'];
 const levels = {
   true: [
-    clc.cyanBright.bold(levelsText[0]),
-    clc.greenBright.bold(levelsText[1]),
-    clc.yellowBright.bold(levelsText[2]),
-    clc.redBright.bold(levelsText[3]),
-    clc.magentaBright.bold(levelsText[4]),
+    colors.cyanBright(colors.bold(levelsText[0])),
+    colors.greenBright(colors.bold(levelsText[1])),
+    colors.yellowBright(colors.bold(levelsText[2])),
+    colors.redBright(colors.bold(levelsText[3])),
+    colors.magentaBright(colors.bold(levelsText[4])),
   ],
   false: levelsText,
 };
@@ -194,8 +194,8 @@ Log.prototype._log = function (level, format, ...params) {
   }
 
   const whiteBrightBold = (str) =>
-    currentUseColor ? clc.whiteBright.bold(str) : str;
-  const white = (str) => (currentUseColor ? clc.white(str) : str);
+    currentUseColor ? colors.whiteBright(colors.bold(str)) : str;
+  const white = (str) => (currentUseColor ? colors.white(str) : str);
 
   if (!format) {
     format = '';

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "as-table": "^1.0.55",
-    "cli-color": "^1.0.0",
+    "picocolors": "^1.1.1",
     "xcraft-core-etc": "^3.0.0"
   },
   "bugs": {


### PR DESCRIPTION
`cli-color` -> `es5-ext` detected as a virus

https://github.com/medikoo/es5-ext/issues/186